### PR TITLE
1folder：全保存于一文件夹并将封面图命名为番号标题演员日期

### DIFF
--- a/jav.js
+++ b/jav.js
@@ -16,6 +16,7 @@ const _ = require('lodash');
 
 const VERSION = require('./package.json').version;
 const baseUrl = 'https://www.3ubdxu00l1lkcjoz5n.com/'
+//timeout链接失败时可改域名为.com .in .me .us .pw javbus2.com seedmm.com，地址发布页https://announce.seedmm.com/website.php
 const searchUrl = '/search';
 var pageIndex = 1;
 var currentPageHtml = null;
@@ -23,20 +24,26 @@ var currentPageHtml = null;
 program
     .version(VERSION)
     .usage('[options]')
-    .option('-p, --parallel <num>', '设置抓取并发连接数，默认值：2', 2)
-    .option('-t, --timeout <num>', '自定义连接超时时间(毫秒)。默认值：30000毫秒')
-    .option('-l, --limit <num>', '设置抓取影片的数量上限，0为抓取全部影片。默认值：0', 0)
-    .option('-o, --output <file_path>', '设置磁链和封面抓取结果的保存位置，默认为当前用户的主目录下的 magnets 文件夹', path.join(userHome, 'magnets'))
-    .option('-s, --search <string>', '搜索关键词，可只抓取搜索结果的磁链或封面')
-    .option('-b, --base <url>', '自定义抓取的起始页')
+    .option('-o, --output <file_path>', '保存位置，勿含空格，已有文件会跳过，例：-o E:|学习资料[1]|，默认为D:|javbus|(竖线应为右斜杠)', 'd:\javbus') 
+    //可更改最后一逗号内为默认保存位置，如下面两行供复制粘贴
+    //默认为E:学习资料 ', 'e:\学习资料' 
+    //默认为用户目录下magnets ', path.join(userHome, 'magnets') 
+    .option('-s, --search <string>', '搜索关键词，可中文/日文/番号，不设置则为从首页开始！番号必须后加-')
+    .option('-b, --base <url>', '自定义抓取起始页，例如可用来抓某类别1j：-b http://www.javbus.in/genre/1j（网址search/后面的关键字不能是汉字/日文，可网页搜后复制过来）')
+    .option('-l, --limit <num>', '设置抓取影片的数量上限，一般一页30个，0或不设置为抓取全部影片', 0)
+    .option('-a, --allmag', '抓取影片的所有磁链(默认只抓取文件体积最大的磁链)')
+    .option('-n, --nomag', '抓取尚无磁链的影片')
+    .option('-p, --parallel <num>', '设置抓取并发连接数，默认值：5', 5)
     .option('-x, --proxy <url>', '使用代理服务器, 例：-x http://127.0.0.1:8087')
-    .option('-n, --nomag', '是否抓取尚无磁链的影片')
-    .option('-a, --allmag', '是否抓取影片的所有磁链(默认只抓取文件体积最大的磁链)')
+    .option('-t, --timeout <num>', '自定义连接超时时间(毫秒)。默认值：5000毫秒 \n\
+    一直timeout链接失败时可更改jav.js的16行域名为.com .in .me .us .pw javbus2.com seedmm.com，\n\
+    地址发布页https://announce.seedmm.com/website.php  \n\
+    (js位于Users-XXX-AppData-Roaming-npm-node_modules-jav-scarpy下)')
     .parse(process.argv);
 
 
 var parallel = parseInt(program.parallel);
-var timeout = parseInt(program.timeout) || 30000;
+var timeout = parseInt(program.timeout) || 5000;
 var proxy = process.env.http_proxy || program.proxy;
 // console.log('proxy: ', proxy);
 request = request.defaults({


### PR DESCRIPTION
希望给个branch叫1folder
在上一个调整帮助文本和改默认并发5超时5秒保存于D盘基础上：
封面信息磁链全保存于一个文件夹下，并将封面图命名为番号标题演员日期；
主要更改了348和349和379行，419和420行使信息磁链，封面全保存于一个文件夹下不建立子文件夹；
截图仍在名为番号的子文件夹方便独立打包压缩；
将封面图命名为番号标题演员日期，基本已解决重命名错误的各种问题，如还有问题请改正408-416行；
其他少量补充注释