### PR TITLE
Fixed bug where category is not correctly recorded

### DIFF
--- a/jav.js
+++ b/jav.js
@@ -231,10 +231,9 @@ function getItemPage(link, index, callback) {
                 let $ = cheerio.load(body);
                 let script = $('script', 'body').eq(2).html();
                 let meta = parse(script);
-
+                meta.category = [];
                 $('div.col-md-3 > p').each(function (i, e) {
                     let text = $(e).text();
-                    meta.category = [];
                     if (text.includes('發行日期:')) {
                         meta.date = text.replace('發行日期: ', '');
                     } else if (text.includes('系列:')) {


### PR DESCRIPTION
`meta.category` is initialized inside the code block resulting in the final `json` file not containing category information.

`meta.category` 的初始化位置导致最终生成的`json`文件不包含类别信息。