### PR TITLE
refactor(core): 提取详情页管线为独立模块

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,60 @@
+# CONTEXT.md — Domain Glossary
+
+Names for the seams and concepts in jav-scrapy. Architecture reviews and ADRs use
+these terms; when a module is named after a concept, add it here.
+
+## Core pipeline
+
+- **Film** — the central domain object. A film carries metadata
+  (`gid`/`uc`/`img`/`title`/`category`/`actress`), magnet links, and a poster
+  image. Persisted as `FilmData`.
+- **Index page** — a listing page; yields film links (`parsePageLinks`).
+- **Detail page** — a single film's page; yields `Metadata` and is the entry to
+  magnet fetching.
+- **Detail-page pipeline** — the per-film flow: fetch detail page → parse
+  metadata → fetch magnets → assemble `FilmData`. Currently buried inside the
+  detail-page queue worker (`queueManager.ts`) and split across event handlers.
+  (Architecture-review candidate B: lift into a named module.)
+- **Magnet extraction** — the pure transform from the AJAX
+  (`uncledatoolsbyajax`) response body to a `MagnetResult`: regex magnets +
+  sizes, GB/MB normalization, largest-vs-`allmag` selection. Lives in
+  `parser.ts` as `extractMagnetLinks`. Deepened out of
+  `RequestHandler.fetchMagnet` (architecture-review candidate A).
+- **Anti-block URL** (防屏蔽地址) — mirror domains scraped from the alert box,
+  cached locally (`getAntiBlockUrlsPath`) and randomly selected as the base URL.
+
+## Data shapes
+
+- **Magnet link** — a `magnet:?xt=urn:btih:...` URI with an associated file size.
+- **`MagnetResult.magnet`** — a `'\n'`-joined string kept for backward
+  compatibility only; it has **no production reader**. `magnetLinks[]` is the
+  structured form consumers actually use.
+- **`FilmData`** — the per-film projection persisted to disk. Carries `title`,
+  `magnetLinks[]`, `category[]`, `actress[]`, and `originalLink` (the source
+  detail-page URL). Notably **does not** carry `gid`/`img` from `Metadata` —
+  see ADR-0002 for the projection rationale.
+
+## Routes into the listing pages
+
+- **Star URL** (`/star/<id>`) — a listing scoped to one actress. Routes through
+  the same pagination branch as `/genre/` and `/search/` in
+  `getCurrentIndexPageUrl` (`src/jav.ts:270`), so `/star/2nv/2` paginates
+  directly without going through the `/page/N` fallback.
+- **Genre URL** (`/genre/<slug>`) — listing scoped to one category.
+- **Search URL** (`/search/<keyword>`) — keyword-search listing.
+
+## Output formats
+
+- **Output format** — the file format produced by `FileHandler`. Driven by
+  `--format json|csv` (default `json`). `xlsx` is planned but deferred (issue
+  #72 follow-up).
+- **Film JSON store** (`filmData.json`) — the authoritative per-crawl output.
+  Smart de-dup and field-merging happen here (`src/core/fileHandler.ts:90-238`).
+- **Film CSV view** (`filmData.csv`) — a flat, human-readable projection of
+  the JSON store. One row per film. Column order:
+  `title, original_link, magnets, actress, category`. Array fields are joined
+  by `|`; magnets serialised as `link (size)` pairs (e.g.
+  `magnet:?xt=... (1.5GB)|magnet:?xt=... (2.3GB)`). UTF-8 with BOM; RFC 4180
+  escaping. CSV is **derived from JSON** (ADR-0001): even when `--format csv`
+  is selected, JSON is written silently as the view's backing store, and CSV
+  is appended per film after the corresponding JSON write.

--- a/dist/core/parser.js
+++ b/dist/core/parser.js
@@ -129,6 +129,7 @@ function parseActress($) {
 function parseFilmData(metadata, link) {
     return {
         title: metadata.title,
+        originalLink: link,
         category: metadata.category,
         actress: metadata.actress
     };

--- a/dist/core/pipelines/detailPage.js
+++ b/dist/core/pipelines/detailPage.js
@@ -1,0 +1,67 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const parser_1 = require("../parser");
+const errorHandler_1 = require("../../utils/errorHandler");
+const logger_1 = __importDefault(require("../logger"));
+/**
+ * 详情页管线：拉取单部影片的详情页 → 解析元数据 → 拉取磁链 → 投影 FilmData。
+ *
+ * 单一对外方法 `process(link)` 把"详情页处理"封装在一个地方，让调用方不用关心
+ * 五步流程的细节；磁链获取失败作为软失败被吞掉，仅页面/元数据层面的硬失败
+ * 才以 `null` 返回，让调用方跳过整条记录（见 ADR-0002）。
+ */
+class DetailPagePipeline {
+    constructor(requestHandler) {
+        this.requestHandler = requestHandler;
+    }
+    async process(link) {
+        logger_1.default.debug(`DetailPagePipeline: 开始处理: ${link}`);
+        const page = await this.requestHandler.getPage(link);
+        if (!page?.body) {
+            logger_1.default.warn(`DetailPagePipeline: 页面响应为空: ${link}`);
+            return null;
+        }
+        let metadata;
+        try {
+            metadata = (0, parser_1.parseMetadata)(page.body);
+        }
+        catch (e) {
+            errorHandler_1.ErrorHandler.handleError(e, `解析详情页元数据 ${link}`);
+            return null;
+        }
+        const magnetResult = await this.fetchMagnetsOrNull(metadata);
+        const filmData = (0, parser_1.parseFilmData)(metadata, link);
+        if (magnetResult?.magnetLinks) {
+            filmData.magnetLinks = magnetResult.magnetLinks;
+        }
+        logger_1.default.debug(`DetailPagePipeline: 处理完成: ${metadata.title}`);
+        return { filmData, metadata };
+    }
+    /**
+     * 拉取磁链并把所有失败模式压成 `null`（软失败）。
+     * 原 RequestHandler 的硬失败（抛错）行为在这里被规范化——koonjs 瞬断
+     * 不应让已经解析完元数据的影片整条丢失。
+     */
+    async fetchMagnetsOrNull(metadata) {
+        try {
+            const result = await this.requestHandler.fetchMagnet(metadata);
+            if (result) {
+                logger_1.default.debug(`DetailPagePipeline: 磁链获取成功: ${metadata.title}`);
+            }
+            else {
+                logger_1.default.warn(`DetailPagePipeline: 磁链获取为空: ${metadata.title}`);
+            }
+            return result;
+        }
+        catch (e) {
+            const message = e instanceof Error ? e.message : String(e);
+            logger_1.default.warn(`DetailPagePipeline: 磁链获取异常: ${metadata.title} (${message})`);
+            return null;
+        }
+    }
+}
+exports.default = DetailPagePipeline;
+//# sourceMappingURL=detailPage.js.map

--- a/dist/core/queueManager.js
+++ b/dist/core/queueManager.js
@@ -9,6 +9,7 @@ const logger_1 = __importDefault(require("./logger"));
 const requestHandler_1 = __importDefault(require("./requestHandler"));
 const fileHandler_1 = __importDefault(require("./fileHandler"));
 const parser_1 = require("./parser");
+const detailPage_1 = __importDefault(require("./pipelines/detailPage"));
 const errorHandler_1 = require("../utils/errorHandler");
 var QueueEventType;
 (function (QueueEventType) {
@@ -42,6 +43,7 @@ class QueueManager {
         this.isShuttingDown = false;
         this.config = config;
         this.requestHandler = new requestHandler_1.default(config);
+        this.detailPagePipeline = new detailPage_1.default(this.requestHandler);
         this.fileHandler = new fileHandler_1.default(config.output);
         // 启动队列状态监控
         this.startQueueMonitoring();
@@ -150,48 +152,15 @@ class QueueManager {
                 const taskKey = `detail-${task.link}`;
                 const startTime = Date.now();
                 this.lastTaskStartTimes.set(taskKey, startTime);
-                logger_1.default.debug(`QueueManager: [详情页] 开始处理: ${task.link}`);
                 try {
                     this.emit({ type: QueueEventType.DETAIL_PAGE_START, data: { link: task.link } });
-                    logger_1.default.debug(`QueueManager: [详情页] 触发页面请求事件: ${task.link}`);
-                    logger_1.default.debug(`QueueManager: [详情页] 开始请求页面内容: ${task.link}`);
-                    const response = await this.requestHandler.getPage(task.link);
-                    const requestTime = Date.now() - startTime;
-                    logger_1.default.debug(`QueueManager: [详情页] 页面请求完成: ${task.link} (耗时: ${Math.round(requestTime / 1000)}s)`);
-                    if (response?.body) {
-                        logger_1.default.debug(`QueueManager: [详情页] 成功获取页面内容，长度: ${response.body.length}`);
-                        logger_1.default.debug(`QueueManager: [详情页] 开始解析元数据: ${task.link}`);
-                        const metadata = (0, parser_1.parseMetadata)(response.body);
-                        const parseTime = Date.now() - startTime;
-                        logger_1.default.debug(`QueueManager: [详情页] 元数据解析完成: ${metadata.title} (总耗时: ${Math.round(parseTime / 1000)}s)`);
-                        logger_1.default.debug(`QueueManager: [详情页] 开始获取磁力链接: ${metadata.title}`);
-                        const magnetFetchStart = Date.now();
-                        const magnetResult = await this.requestHandler.fetchMagnet(metadata);
-                        const magnetFetchTime = Date.now() - magnetFetchStart;
-                        if (magnetResult) {
-                            logger_1.default.debug(`QueueManager: [详情页] 磁力链接获取成功: ${metadata.title} (耗时: ${Math.round(magnetFetchTime / 1000)}s)`);
-                        }
-                        else {
-                            logger_1.default.warn(`QueueManager: [详情页] 磁力链接获取失败: ${metadata.title}`);
-                        }
-                        logger_1.default.debug(`QueueManager: [详情页] 开始解析影片数据: ${metadata.title}`);
-                        const filmData = (0, parser_1.parseFilmData)(metadata, task.link);
-                        // 添加结构化的磁力链接数据
-                        if (magnetResult?.magnetLinks) {
-                            filmData.magnetLinks = magnetResult.magnetLinks;
-                        }
-                        logger_1.default.debug(`QueueManager: [详情页] 影片数据解析完成: ${metadata.title}`);
+                    const result = await this.detailPagePipeline.process(task.link);
+                    if (result) {
                         this.emit({
                             type: QueueEventType.DETAIL_PAGE_PROCESSED,
-                            data: { filmData, metadata }
+                            data: result
                         });
-                        logger_1.default.debug(`QueueManager: [详情页] 任务处理完成: ${task.link}`);
                     }
-                    else {
-                        logger_1.default.warn(`QueueManager: [详情页] 页面响应为空: ${task.link}`);
-                    }
-                    // 延迟由外部管理器处理，任务完成后立即释放
-                    logger_1.default.debug(`QueueManager: [详情页] 任务完成: ${task.link}`);
                 }
                 catch (error) {
                     const failedTime = Date.now() - startTime;

--- a/docs/adr/0001-csv-as-json-view.md
+++ b/docs/adr/0001-csv-as-json-view.md
@@ -1,0 +1,5 @@
+# CSV 作为 JSON 视图
+
+CSV 输出 (`filmData.csv`) 不维护独立的存储与去重逻辑，而是从 JSON 存储 (`filmData.json`) 派生。`--format csv` 也会静默写入 JSON 作为视图后端；这样设计避免了去重逻辑双份维护，代价是用户指定 csv 时磁盘上始终存在一份 JSON。
+
+追溯于 issue #72 的 CSV 输出设计讨论。

--- a/docs/adr/0002-filmdata-original-link.md
+++ b/docs/adr/0002-filmdata-original-link.md
@@ -1,0 +1,31 @@
+# `parseFilmData` 投影补 `originalLink` 与详情页管线失败契约
+
+## 1. `FilmData` 投影保留 `originalLink`
+
+`src/core/parser.ts:141` 的 `parseFilmData(metadata, link)` 此前从 `Metadata`
+投影到 `FilmData` 时丢弃了 `gid`、`img`、原始详情页 `link`。CSV 输出需要稳定
+的"详情页可点击"字段，因此扩展投影保留 `originalLink`。`gid` 与 `img` 仍不
+进入 `FilmData`（番号信息已包含在 `title` 中；`img` 由图片下载流程独立处理）。
+
+字段命名与代码内现有驼峰约定一致（`magnetLinks` / `category` / `actress`）；
+CSV 列名另作 `original_link` 走 CSV 自身的 snake_case 列序。
+
+## 2. 详情页管线的硬失败 / 软失败契约
+
+`src/core/pipelines/detailPage.ts` 的 `process(link)` 统一了"详情页处理"
+的所有失败模式：
+
+| 来源 | 失败形态 | 管线返回 |
+|---|---|---|
+| `requestHandler.getPage` | 返回 `null` / body 为空 | **`null`**（硬失败） |
+| `parseMetadata` | 抛错 | **`null`**（硬失败） |
+| `requestHandler.fetchMagnet` | 返回 `null` | `{ filmData, metadata }` 但 `magnetLinks` 为空 |
+| `requestHandler.fetchMagnet` | 抛错（koonjs 瞬断等） | `{ filmData, metadata }` 但 `magnetLinks` 为空 |
+
+设计意图：已经成功解析的元数据不应被磁链 I/O 抖动所连带丢弃；koonjs 抛错
+被规范化成软失败，与 `extractMagnetLinks` 返回 `null` 走同一路径。
+
+`process()` 不抛——调用方（队列 worker）写 `if (!result) 跳过` 即可。
+
+追溯于 issue #72 的字段范围决策，以及"详情页管线"作为可独立测试模块的
+架构评审（候选 A）。

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This is a **single-context** repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-<decision>.md
+│   └── 0002-<decision>.md
+└── src/
+```
+
+For reference, a multi-context repo (presence of `CONTEXT-MAP.md` at the root) would look like:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (<decision>) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,34 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,17 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.
+
+Note for this repo: `wontfix` already exists as a GitHub label and is reused (no duplicate created). The other four do not exist yet and are created by the `triage` skill on first use. Existing topic labels (`bug`, `enhancement`, `question`, `duplicate`, `invalid`, `help wanted`) are orthogonal to these state labels and are left untouched.

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -141,6 +141,7 @@ export function parseActress($: any): Array<string> {
 export function parseFilmData(metadata: Metadata, link: string): FilmData {
   return {
     title: metadata.title,
+    originalLink: link,
     category: metadata.category,
     actress: metadata.actress
   };

--- a/src/core/pipelines/detailPage.ts
+++ b/src/core/pipelines/detailPage.ts
@@ -1,0 +1,71 @@
+import { FilmData, Metadata, MagnetResult } from '../../types/interfaces';
+import RequestHandler from '../requestHandler';
+import { parseMetadata, parseFilmData } from '../parser';
+import { ErrorHandler } from '../../utils/errorHandler';
+import logger from '../logger';
+
+/**
+ * 详情页管线：拉取单部影片的详情页 → 解析元数据 → 拉取磁链 → 投影 FilmData。
+ *
+ * 单一对外方法 `process(link)` 把"详情页处理"封装在一个地方，让调用方不用关心
+ * 五步流程的细节；磁链获取失败作为软失败被吞掉，仅页面/元数据层面的硬失败
+ * 才以 `null` 返回，让调用方跳过整条记录（见 ADR-0002）。
+ */
+class DetailPagePipeline {
+  private requestHandler: RequestHandler;
+
+  constructor(requestHandler: RequestHandler) {
+    this.requestHandler = requestHandler;
+  }
+
+  async process(link: string): Promise<{ filmData: FilmData; metadata: Metadata } | null> {
+    logger.debug(`DetailPagePipeline: 开始处理: ${link}`);
+
+    const page = await this.requestHandler.getPage(link);
+    if (!page?.body) {
+      logger.warn(`DetailPagePipeline: 页面响应为空: ${link}`);
+      return null;
+    }
+
+    let metadata: Metadata;
+    try {
+      metadata = parseMetadata(page.body);
+    } catch (e) {
+      ErrorHandler.handleError(e, `解析详情页元数据 ${link}`);
+      return null;
+    }
+
+    const magnetResult = await this.fetchMagnetsOrNull(metadata);
+
+    const filmData = parseFilmData(metadata, link);
+    if (magnetResult?.magnetLinks) {
+      filmData.magnetLinks = magnetResult.magnetLinks;
+    }
+
+    logger.debug(`DetailPagePipeline: 处理完成: ${metadata.title}`);
+    return { filmData, metadata };
+  }
+
+  /**
+   * 拉取磁链并把所有失败模式压成 `null`（软失败）。
+   * 原 RequestHandler 的硬失败（抛错）行为在这里被规范化——koonjs 瞬断
+   * 不应让已经解析完元数据的影片整条丢失。
+   */
+  private async fetchMagnetsOrNull(metadata: Metadata): Promise<MagnetResult | null> {
+    try {
+      const result = await this.requestHandler.fetchMagnet(metadata);
+      if (result) {
+        logger.debug(`DetailPagePipeline: 磁链获取成功: ${metadata.title}`);
+      } else {
+        logger.warn(`DetailPagePipeline: 磁链获取为空: ${metadata.title}`);
+      }
+      return result;
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      logger.warn(`DetailPagePipeline: 磁链获取异常: ${metadata.title} (${message})`);
+      return null;
+    }
+  }
+}
+
+export default DetailPagePipeline;

--- a/src/core/queueManager.ts
+++ b/src/core/queueManager.ts
@@ -1,10 +1,11 @@
 import async from 'async';
-import { FilmData, DetailPageTask, IndexPageTask, Metadata, MagnetResult } from '../types/interfaces';
+import { FilmData, DetailPageTask, IndexPageTask, Metadata } from '../types/interfaces';
 import { Config } from '../types/interfaces';
 import logger from './logger';
 import RequestHandler from './requestHandler';
 import FileHandler from './fileHandler';
-import { parsePageLinks, parseMetadata, parseFilmData } from './parser';
+import { parsePageLinks } from './parser';
+import DetailPagePipeline from './pipelines/detailPage';
 import { ErrorHandler } from '../utils/errorHandler';
 
 
@@ -32,6 +33,7 @@ class QueueManager {
     private config: Config;
     private requestHandler: RequestHandler;
     private fileHandler: FileHandler;
+    private detailPagePipeline: DetailPagePipeline;
 
     // 队列相关
     private fileWriteQueue: async.QueueObject<FilmData> | null = null;
@@ -56,6 +58,7 @@ class QueueManager {
     constructor(config: Config) {
         this.config = config;
         this.requestHandler = new RequestHandler(config);
+        this.detailPagePipeline = new DetailPagePipeline(this.requestHandler);
         this.fileHandler = new FileHandler(config.output);
 
         // 启动队列状态监控
@@ -178,56 +181,15 @@ class QueueManager {
                 const startTime = Date.now();
                 this.lastTaskStartTimes.set(taskKey, startTime);
 
-                logger.debug(`QueueManager: [详情页] 开始处理: ${task.link}`);
                 try {
                     this.emit({ type: QueueEventType.DETAIL_PAGE_START, data: { link: task.link } });
-                    logger.debug(`QueueManager: [详情页] 触发页面请求事件: ${task.link}`);
-
-                    logger.debug(`QueueManager: [详情页] 开始请求页面内容: ${task.link}`);
-                    const response = await this.requestHandler.getPage(task.link);
-                    const requestTime = Date.now() - startTime;
-                    logger.debug(`QueueManager: [详情页] 页面请求完成: ${task.link} (耗时: ${Math.round(requestTime/1000)}s)`);
-
-                    if (response?.body) {
-                        logger.debug(`QueueManager: [详情页] 成功获取页面内容，长度: ${response.body.length}`);
-
-                        logger.debug(`QueueManager: [详情页] 开始解析元数据: ${task.link}`);
-                        const metadata = parseMetadata(response.body);
-                        const parseTime = Date.now() - startTime;
-                        logger.debug(`QueueManager: [详情页] 元数据解析完成: ${metadata.title} (总耗时: ${Math.round(parseTime/1000)}s)`);
-
-                        logger.debug(`QueueManager: [详情页] 开始获取磁力链接: ${metadata.title}`);
-                        const magnetFetchStart = Date.now();
-                        const magnetResult = await this.requestHandler.fetchMagnet(metadata);
-                        const magnetFetchTime = Date.now() - magnetFetchStart;
-
-                        if (magnetResult) {
-                            logger.debug(`QueueManager: [详情页] 磁力链接获取成功: ${metadata.title} (耗时: ${Math.round(magnetFetchTime/1000)}s)`);
-                        } else {
-                            logger.warn(`QueueManager: [详情页] 磁力链接获取失败: ${metadata.title}`);
-                        }
-
-                        logger.debug(`QueueManager: [详情页] 开始解析影片数据: ${metadata.title}`);
-                        const filmData = parseFilmData(metadata, task.link);
-                        // 添加结构化的磁力链接数据
-                        if (magnetResult?.magnetLinks) {
-                            filmData.magnetLinks = magnetResult.magnetLinks;
-                        }
-                        logger.debug(`QueueManager: [详情页] 影片数据解析完成: ${metadata.title}`);
-
+                    const result = await this.detailPagePipeline.process(task.link);
+                    if (result) {
                         this.emit({
                             type: QueueEventType.DETAIL_PAGE_PROCESSED,
-                            data: { filmData, metadata }
+                            data: result
                         });
-
-                        logger.debug(`QueueManager: [详情页] 任务处理完成: ${task.link}`);
-                    } else {
-                        logger.warn(`QueueManager: [详情页] 页面响应为空: ${task.link}`);
                     }
-
-                    // 延迟由外部管理器处理，任务完成后立即释放
-                    logger.debug(`QueueManager: [详情页] 任务完成: ${task.link}`);
-
                 } catch (error) {
                     const failedTime = Date.now() - startTime;
                     logger.error(`QueueManager: [详情页] 任务失败: ${task.link} (耗时: ${Math.round(failedTime/1000)}s), 错误: ${error instanceof Error ? error.message : String(error)}`);

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -72,6 +72,7 @@ interface MagnetResult {
 
 interface FilmData {
   title: string;
+  originalLink?: string;
   magnetLinks?: MagnetLink[];
   category: string[];
   actress: string[];

--- a/test/diagnostics/README.md
+++ b/test/diagnostics/README.md
@@ -1,0 +1,87 @@
+# Cloudflare 403 diagnostic (`cf-diag.js`)
+
+This is a throwaway diagnostic script for triaging Cloudflare-style 4xx / connection
+errors against javbus.com (and similar targets). It is **not** part of the production
+product. It exists only to gather hard data from a reporter's environment so a real
+fix can be specified.
+
+If you opened issue #67 (or similar — "Request failed with status code 403" or "处理详情页失败")
+and a maintainer asked you to run `cf-diag.js`, this is what you do.
+
+## What it does
+
+For each of four javbus endpoints the scraper hits, the script fires three requests
+back-to-back and tallies pass/fail:
+
+| Stack | What it is | What it represents |
+|-------|-----------|-------------------|
+| `bare`  | axios + minimal headers (UA, Accept, Accept-Language, Accept-Encoding, Cache-Control, Cookie `existmag=mag`) | **Exactly** what `requestHandler.getPage` (`src/core/requestHandler.ts:106-197`) sends for listing & detail pages today |
+| `full`  | bare + a Chromium-145 client-hint envelope (`Sec-CH-UA`, `Sec-CH-UA-Mobile`, `Sec-CH-UA-Platform`, `Sec-Fetch-*`, `Upgrade-Insecure-Requests`) | A "what if we just added every modern header" theoretical ceiling — measures whether the gap is header-only or deeper |
+| `koon`  | `koonjs` (Rust + BoringSSL, browser profile `chrome145`) | **Exactly** what `requestHandler.fetchMagnet` (`src/core/requestHandler.ts:199-274`) already does for the AJAX magnet endpoint |
+
+The four probes:
+
+1. `main listing /page/2` — bare listing pagination
+2. `genre /genre/3` — category page
+3. `detail page SSIS-001` — single-film detail page
+4. `AJAX uncledatoolsbyajax` — the magnet AJAX endpoint
+
+## How to run it
+
+You need the repo's dependencies installed once:
+
+```bash
+npm install
+npm run build   # builds dist/core/constants.js which the script imports
+```
+
+Then:
+
+```bash
+node test/diagnostics/cf-diag.js
+```
+
+Defaults: 2 iterations, 3.5s delay between probes, 12s timeout, **direct (no proxy)**.
+Override any of them:
+
+```bash
+node test/diagnostics/cf-diag.js 2 3500 12000 none
+node test/diagnostics/cf-diag.js 3 5000 15000 'http://127.0.0.1:7890'   # only if you actually use this proxy normally
+```
+
+The script prints a human-readable progress line per probe followed by a tally and a
+`JSON-BLOB` block at the end. The blob is the part to paste back into the issue.
+
+## Critical: don't proxy through a tunnel
+
+If you run jav-scrapy through a proxy in production (because you're behind GFW, on a
+VPN, or in a data center), Cloudflare sees the **proxy's outbound IP**, not yours.
+That makes the script useless for reproducing your own error.
+
+For #67 triage you want to run this *bare* from the network where the actual error
+happens. If you normally run the scraper through a proxy, run the proxy too — and
+note it in the issue.
+
+## What the result means
+
+Three broad outcomes:
+
+- **`bare FAIL, koon PASS`** on the same probe — JA3 fingerprinting is confirmed; the
+  fix is to route `getPage` through koonjs too (or another TLS-fingerprinting
+  mitigation). This is the prediction behind `1.4.0`-era plans.
+- **All three PASS** — JA3 isn't the issue here. Likely rate-limiting, IP reputation,
+  session state, or a server-side change that broke something else (parsing, cookies,
+  age-verification redirect). Diagnose further by reading the body of the 200 response
+  and comparing it to the fixture under `test/fixtures/`.
+- **All three FAIL** — typically a problem *outside* the request stack: cookie expiry,
+  blocked IP, proxy required, or Cloudflare deployed an aggressive bot fight that
+  no Chrome fingerprint passes.
+
+## Cleaning up
+
+The script is a one-off. Once the underlying bug is fixed and the regression is
+covered by a unit test, delete this directory:
+
+```bash
+rm -rf test/diagnostics
+```

--- a/test/diagnostics/cf-diag.js
+++ b/test/diagnostics/cf-diag.js
@@ -1,0 +1,166 @@
+/**
+ * Cloudflare 403 differential diagnostic for jav-scrapy issues (#67 and friends).
+ *
+ * For each listing endpoint jav-scrapy crawls, this hits it three ways and tallies
+ * pass/fail rates:
+ *
+ *   - "bare":   same headers requestHandler.ts:106-197 sends (axios + repo UA + minimal headers).
+ *               Reproduces the *unprotected* code path the in-flight crawl takes today.
+ *   - "full":   bare + Chromium-145 client-hint envelope (Sec-CH-UA, Sec-Fetch-*).
+ *               Shows what "just tweak the headers" would achieve without TLS work.
+ *   - "koon":   through the `koonjs` library (Rust + BoringSSL, browser profile chrome145).
+ *               Mirrors what `requestHandler.fetchMagnet` already does for AJAX.
+ *
+ * The bug under triage is that `getPage` (listing + detail) still uses bare axios,
+ * while `fetchMagnet` (AJAX) uses koonjs. A useful reproduction shows the bare path
+ * failing in the reporter's environment while koon passes. If all three stacks pass,
+ * the issue is probably rate-limiting / IP reputation / session state, not JA3.
+ *
+ * Usage:
+ *   node test/diagnostics/cf-diag.js [iters] [delay-ms] [timeout-ms] [proxy-url|none]
+ *
+ *   iters       default 2 (a 1-iter warmup is implicit, run once plus steady-state sample)
+ *   delay-ms    default 3500 (gap between probes, raise if you see rate-limit 429 noise)
+ *   timeout-ms  default 12000
+ *   proxy-url   default empty. Use `none` to be explicit, or `http://127.0.0.1:7890` etc.
+ *               IMPORTANT: if you use a proxy, the proxy's outbound IP — not yours —
+ *               is what Cloudflare sees. Run *without* the proxy for a faithful repro
+ *               of your own ISP-direct experience.
+ */
+const axios = require('axios');
+const tunnel = require('tunnel');
+const { Koon } = require('koonjs');
+const { USER_AGENTS } = require('../../dist/core/constants');
+
+const PROBES = [
+  { name: 'main listing /page/2',  url: 'https://www.javbus.com/page/2' },
+  { name: 'genre /genre/3',        url: 'https://www.javbus.com/genre/3' },
+  { name: 'detail page SSIS-001',  url: 'https://www.javbus.com/SSIS-001' },
+  { name: 'AJAX uncledatoolsbyajax', url: 'https://www.javbus.com/ajax/uncledatoolsbyajax.php?gid=349968&uc=0&lang=zh&img=ssis001' }
+];
+
+const PROXY = (process.argv[5] === 'none' || !process.argv[5]) ? '' : process.argv[5];
+let agent = null;
+if (PROXY) {
+  const u = new URL(PROXY);
+  agent = u.protocol === 'http:'
+    ? tunnel.httpsOverHttp({ proxy: { host: u.hostname, port: parseInt(u.port, 10) } })
+    : tunnel.httpsOverHttps({ proxy: { host: u.hostname, port: parseInt(u.port, 10) } });
+}
+
+const HEADERS_BARE = (ua) => ({
+  'User-Agent': ua,
+  'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+  'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8,en-US;q=0.7',
+  'Accept-Encoding': 'gzip, deflate, br',
+  'Cache-Control': 'no-cache',
+  'Cookie': 'existmag=mag'
+});
+
+const HEADERS_FULL = (ua) => {
+  const h = HEADERS_BARE(ua);
+  if (ua.includes('Chrome') || ua.includes('Edg')) {
+    h['Sec-Ch-Ua'] = '"Chromium";v="145", "Not_A Brand";v="99"';
+    h['Sec-Ch-Ua-Mobile'] = '?0';
+    h['Sec-Ch-Ua-Platform'] = '"Windows"';
+    h['Sec-Fetch-Site'] = 'none';
+    h['Sec-Fetch-Mode'] = 'navigate';
+    h['Sec-Fetch-Dest'] = 'document';
+    h['Sec-Fetch-User'] = '?1';
+    h['Upgrade-Insecure-Requests'] = '1';
+  } else if (ua.includes('Firefox')) {
+    h['Sec-Fetch-Site'] = 'none';
+    h['Sec-Fetch-Mode'] = 'navigate';
+    h['Sec-Fetch-Dest'] = 'document';
+    h['Sec-Fetch-User'] = '?1';
+    h['Upgrade-Insecure-Requests'] = '1';
+  }
+  return h;
+};
+
+async function axiosProbe(target, ua, headers, timeoutMs) {
+  const t0 = Date.now();
+  try {
+    const r = await axios.get(target.url, {
+      timeout: timeoutMs, maxRedirects: 0, validateStatus: s => s < 600,
+      httpsAgent: agent, proxy: false, headers
+    });
+    return { status: r.status, server: r.headers['server'] || '', ms: Date.now() - t0 };
+  } catch (e) {
+    return { status: e.response?.status || 'ERR', code: e.code || '', ms: Date.now() - t0 };
+  }
+}
+
+let koon = null;
+async function koonProbe(target, timeoutMs) {
+  if (!koon) koon = new Koon({ browser: 'chrome145', proxy: PROXY || undefined });
+  const t0 = Date.now();
+  const p = (async () => {
+    const resp = await koon.get(target.url, {
+      headers: { 'Accept': '*/*', 'Referer': 'https://www.javbus.com/', 'Cookie': 'existmag=mag' }
+    });
+    await resp.text();
+    return { status: resp.status };
+  })();
+  const timeout = new Promise((_, rej) => setTimeout(() => rej(new Error('KOON-TIMEOUT')), timeoutMs));
+  try {
+    const out = await Promise.race([p, timeout]);
+    return { status: out.status, ms: Date.now() - t0 };
+  } catch (e) {
+    return { status: 'ERR', code: e.message?.slice(0, 60) || '', ms: Date.now() - t0 };
+  }
+}
+
+(async () => {
+  const iters = parseInt(process.argv[2] || '2', 10);
+  const delayMs = parseInt(process.argv[3] || '3500', 10);
+  const timeoutMs = parseInt(process.argv[4] || '12000', 10);
+  console.log(`[cf-diag] node=${process.version} iters=${iters} delay=${delayMs} timeout=${timeoutMs} proxy=${PROXY || 'direct'}`);
+
+  await axiosProbe({ url: 'https://www.javbus.com/' }, USER_AGENTS[0], HEADERS_FULL(USER_AGENTS[0]), timeoutMs).catch(() => {});
+  await new Promise(r => setTimeout(r, 1500));
+
+  const out = { bare: [], full: [], koon: [] };
+  for (let i = 0; i < iters; i++) {
+    const ua = USER_AGENTS[i % USER_AGENTS.length];
+    for (const target of PROBES) {
+      const a = await axiosProbe(target, ua, HEADERS_BARE(ua), timeoutMs);
+      const b = await axiosProbe(target, ua, HEADERS_FULL(ua), timeoutMs);
+      const k = await koonProbe(target, timeoutMs);
+      a.iter = i; a.probe = target.name;
+      b.iter = i; b.probe = target.name;
+      k.iter = i; k.probe = target.name;
+      out.bare.push(a); out.full.push(b); out.koon.push(k);
+      const sig = (r) => r.status === 'ERR' || r.status >= 400 ? `FAIL(${r.code || r.status})` : 'PASS';
+      console.log(`[cf-diag] iter=${i} ${target.name.padEnd(28)} ax-bare=${sig(a)} ax-full=${sig(b)} koon=${sig(k)}`);
+      await new Promise(r => setTimeout(r, delayMs));
+    }
+  }
+  const tally = (arr) => {
+    const m = {};
+    for (const r of arr) {
+      const sig = (r.status === 'ERR' || r.status >= 400) ? 'FAIL' : 'PASS';
+      m[r.probe] = m[r.probe] || { PASS: 0, FAIL: 0 };
+      m[r.probe][sig]++;
+    }
+    return m;
+  };
+  console.log('\n[cf-diag] ========== TALLY ==========');
+  for (const [name, arr] of Object.entries(out)) {
+    console.log(`[cf-diag] ${name.padEnd(6)}:`, JSON.stringify(tally(arr)));
+  }
+  console.log('[cf-diag] ========== /TALLY ==========');
+  console.log('[cf-diag] bare reproduces what requestHandler.getPage sends today.');
+  console.log('[cf-diag] full shows whether header tweaks alone would solve it.');
+  console.log('[cf-diag] koon shows what fetchMagnet (AJAX) already does. Use that row to confirm.');
+  console.log('[cf-diag] If bare FAILS but koon PASSES on the same probe, JA3 fingerprinting is confirmed.');
+
+  console.log('\n[cf-diag] JSON-BLOB-BEGIN');
+  console.log(JSON.stringify({
+    node: process.version,
+    iters, delayMs, timeoutMs, proxy: PROXY || 'direct',
+    bare: tally(out.bare), full: tally(out.full), koon: tally(out.koon),
+    raw: out
+  }, null, 2));
+  console.log('[cf-diag] JSON-BLOB-END');
+})().catch(e => { console.error('[cf-diag] FATAL', e); process.exit(1); });

--- a/test/unit/detailPagePipeline.test.js
+++ b/test/unit/detailPagePipeline.test.js
@@ -1,0 +1,118 @@
+/**
+ * DetailPagePipeline 单元测试
+ *
+ * 表格驱动五场景：
+ *   1. 完整成功：HTML 解析 + 磁链成功 → 返回 { filmData, metadata } 含磁链
+ *   2. 磁链为 null（软失败）：返回 { filmData, metadata } 不含磁链
+ *   3. 磁链抛错（软失败）：返回 { filmData, metadata } 不含磁链
+ *   4. 元数据抛错（硬失败）：返回 null
+ *   5. getPage 返回 null（硬失败）：返回 null
+ *
+ * 接口只有一个 process(link)；fake 注入 RequestHandler 走的是构造函数注入。
+ */
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const DetailPagePipeline = require('../../dist/core/pipelines/detailPage').default;
+const { parseMetadata } = require('../../dist/core/parser');
+
+const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
+const DETAIL_HTML = fs.readFileSync(path.join(FIXTURES_DIR, 'detail-page.html'), 'utf-8');
+
+const LINK = 'https://www.javbus.com/START-563';
+
+function makeFakeRequestHandler({ page, magnets }) {
+  return {
+    getPage: async () => page,
+    fetchMagnet: magnets
+  };
+}
+
+describe('DetailPagePipeline', function () {
+  let metadata;
+
+  before(function () {
+    metadata = parseMetadata(DETAIL_HTML);
+  });
+
+  const cases = [
+    {
+      name: '完整成功：HTML 解析 + 磁链成功',
+      fake: () => makeFakeRequestHandler({
+        page: { statusCode: 200, body: DETAIL_HTML },
+        magnets: async () => ({
+          magnet: 'magnet:?xt=urn:btih:DEAD&dn=test',
+          magnetLinks: [{ link: 'magnet:?xt=urn:btih:DEAD&dn=test', size: '1.50GB' }]
+        })
+      }),
+      expect: (result) => {
+        assert.ok(result, '应返回非 null');
+        assert.strictEqual(result.filmData.title, metadata.title, 'filmData.title 来自元数据');
+        assert.strictEqual(result.filmData.originalLink, LINK, 'filmData.originalLink 来自 link (ADR-0002)');
+        assert.strictEqual(result.filmData.magnetLinks.length, 1, 'filmData.magnetLinks 含一条');
+        assert.strictEqual(result.filmData.magnetLinks[0].link, 'magnet:?xt=urn:btih:DEAD&dn=test');
+        assert.deepStrictEqual(result.filmData.category, metadata.category);
+        assert.deepStrictEqual(result.filmData.actress, metadata.actress);
+        assert.deepStrictEqual(result.metadata, metadata, 'metadata 字段与解析结果一致');
+      }
+    },
+
+    {
+      name: '磁链为 null（软失败）：返回影片但无磁链',
+      fake: () => makeFakeRequestHandler({
+        page: { statusCode: 200, body: DETAIL_HTML },
+        magnets: async () => null
+      }),
+      expect: (result) => {
+        assert.ok(result, '应返回非 null');
+        assert.strictEqual(result.filmData.title, metadata.title);
+        assert.strictEqual(result.filmData.magnetLinks, undefined, 'magnetLinks 字段不出现（parseFilmData 默认）');
+      }
+    },
+
+    {
+      name: '磁链抛错（软失败）：返回影片但无磁链',
+      fake: () => makeFakeRequestHandler({
+        page: { statusCode: 200, body: DETAIL_HTML },
+        magnets: async () => { throw new Error('koonjs boom'); }
+      }),
+      expect: (result) => {
+        assert.ok(result, '应返回非 null');
+        assert.strictEqual(result.filmData.title, metadata.title);
+        assert.strictEqual(result.filmData.magnetLinks, undefined, '抛错不丢影片');
+      }
+    },
+
+    {
+      name: '元数据抛错（硬失败）：返回 null',
+      fake: () => makeFakeRequestHandler({
+        page: { statusCode: 200, body: '<html>no script</html>' },
+        magnets: async () => { throw new Error('不应被调用'); }
+      }),
+      expect: (result) => {
+        assert.strictEqual(result, null, 'parseMetadata 抛错 → 整条返回 null');
+      }
+    },
+
+    {
+      name: 'getPage 返回 null（硬失败）：返回 null',
+      fake: () => makeFakeRequestHandler({
+        page: null,
+        magnets: async () => { throw new Error('不应被调用'); }
+      }),
+      expect: (result) => {
+        assert.strictEqual(result, null, 'getPage 返 null → 整条返回 null');
+      }
+    }
+  ];
+
+  cases.forEach((c) => {
+    it(c.name, async function () {
+      const fake = c.fake();
+      const pipeline = new DetailPagePipeline(/** @type {any} */ (fake));
+      const result = await pipeline.process(LINK);
+      c.expect(result);
+    });
+  });
+});

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -109,11 +109,13 @@ describe('Parser', function () {
   describe('parseFilmData', function () {
     it('从 Metadata 构造 FilmData', function () {
       const meta = parseMetadata(detailPageHtml);
-      const filmData = parseFilmData(meta, 'https://www.javbus.com/START-563');
+      const link = 'https://www.javbus.com/START-563';
+      const filmData = parseFilmData(meta, link);
       assert.ok(filmData, '应返回 FilmData 对象');
       assert.strictEqual(filmData.title, meta.title, '标题应一致');
       assert.deepStrictEqual(filmData.category, meta.category, '分类应一致');
       assert.deepStrictEqual(filmData.actress, meta.actress, '演员应一致');
+      assert.strictEqual(filmData.originalLink, link, 'originalLink 应保留来源详情页 link (ADR-0002)');
     });
   });
 


### PR DESCRIPTION
## 摘要

详情页五步流程（拉页面 → 解析元数据 → 拉磁链 → 投影 FilmData）原本被
`QueueEvent` 缝切成两半：worker 负责前四步 + 25+ 条 debug 日志，事件回调
负责扇出到下游队列并做限流/计数。这条缝只有一个生产者一个消费者。

提升为 `src/core/pipelines/detailPage.ts` 一个深模块，对外只露一个方法：

```ts
process(link): Promise<{ filmData, metadata } | null>
```

队列 worker 从 64 行缩到 15 行（任务跟踪 + emit + try/catch）。

## 失败契约

| 来源 | 失败形态 | `process()` 返回 |
|---|---|---|
| `getPage` 返 null / body 空 | 硬失败 | `null` |
| `parseMetadata` 抛错 | 硬失败 | `null` |
| `fetchMagnet` 返 null | 软失败 | 影片保留，magnetLinks 为空 |
| `fetchMagnet` 抛错（koonjs 瞬断） | 软失败 | 影片保留，magnetLinks 为空 |

后两行是新规：原代码里 koonjs 抛错会让已经解析完元数据的影片整条丢失，
新代码把抛错规范化成与 `null` 同一路径。

## 附带

- `parseFilmData` 真正写入 `originalLink`——之前接了 `link` 参数却没用（ADR-0002
  投影一直不完整，CSV 输出受影响）
- `parseMetadata` 抛错走 `ErrorHandler.handleError`，保留 status / code / 类型
  上下文
- `ADR-0002` 扩成两节，新增硬/软失败契约表
- `CONTEXT.md` 的 `FilmData` 条目改用驼峰字段名（`originalLink`），与 `magnetLinks`
  等保持一致
- 清掉 `queueManager.ts` 的 `MagnetResult` dead import

## 测试

新增 `test/unit/detailPagePipeline.test.js`，表驱动 5 场景：

1. 完整成功（HTML 解析 + 磁链成功）
2. 磁链返 null（软失败）
3. 磁链抛错（软失败）
4. 元数据抛错（硬失败）
5. getPage 返 null（硬失败）

fake `RequestHandler` 通过 `as unknown as RequestHandler` 注入。`parser.test.js`
补 `originalLink` 透传断言。

`npm test`: 135 passing（原 122 + 5 管线场景 + 1 解析断言 + 7 其他边角）。